### PR TITLE
Use matrices for portal transforms

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,22 +11,23 @@ use glam::DVec2;
 use glam::DVec3;
 use std::f64::consts::PI;
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
-pub struct Circle {
-    pos: DVec2,
-    rot: f64,
-    r: f64,
+fn trs_to_mat(pos: DVec2, rot: f64, scale: f64) -> DMat3 {
+    DMat3::from_scale_angle_translation(DVec2::splat(scale), rot, pos)
 }
 
-impl Default for Circle {
-    fn default() -> Self {
-        Circle {
-            pos: DVec2::ZERO,
-            rot: 0.,
-            r: 1.,
-        }
-    }
+fn mat_to_trs(mat: &DMat3) -> (DVec2, f64, f64) {
+    let pos = mat.z_axis.xy();
+    let x_axis = mat.x_axis.xy();
+    let scale = x_axis.length();
+    let rot = x_axis.y.atan2(x_axis.x);
+    (pos, rot, scale)
 }
+
+fn set_pos(mat: &mut DMat3, pos: DVec2) {
+    let (_, rot, scale) = mat_to_trs(mat);
+    *mat = trs_to_mat(pos, rot, scale);
+}
+
 
 #[derive(serde::Deserialize, serde::Serialize, Default, Clone, Copy, Debug, PartialEq)]
 pub enum PortalType {
@@ -38,24 +39,16 @@ pub enum PortalType {
 
 #[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Portal {
-    c1: Circle,
-    c2: Circle,
+    c1: DMat3,
+    c2: DMat3,
     portal_type: PortalType,
 }
 
 impl Default for Portal {
     fn default() -> Self {
         Self {
-            c1: Circle {
-                pos: DVec2::new(-1.01, 0.),
-                rot: 0.,
-                r: 1.,
-            },
-            c2: Circle {
-                pos: DVec2::new(1.01, 0.),
-                rot: 0.,
-                r: 1.,
-            },
+            c1: trs_to_mat(DVec2::new(-1.01, 0.), 0.0, 1.0),
+            c2: trs_to_mat(DVec2::new(1.01, 0.), 0.0, 1.0),
             portal_type: Default::default(),
         }
     }
@@ -89,23 +82,20 @@ impl Ray {
     }
 }
 
-fn ray_circle_intersection(ray: &Ray, circle: &Circle) -> Option<f64> {
-    let oc = ray.o - circle.pos;
-
-    let a = ray.d.dot(ray.d);
-    let b = 2.0 * oc.dot(ray.d);
-    let c = oc.dot(oc) - circle.r * circle.r;
-
+fn ray_circle_intersection(ray: &Ray, circle: &DMat3) -> Option<f64> {
+    let inv = circle.inverse();
+    let o = inv.transform_point2(ray.o);
+    let d = inv.transform_vector2(ray.d);
+    let a = d.dot(d);
+    let b = 2.0 * o.dot(d);
+    let c = o.dot(o) - 1.0;
     let discriminant = b * b - 4.0 * a * c;
-
     if discriminant < 0.0 {
         return None;
     }
-
     let sqrt_discriminant = discriminant.sqrt();
     let t1 = (-b - sqrt_discriminant) / (2.0 * a);
     let t2 = (-b + sqrt_discriminant) / (2.0 * a);
-
     if t1 >= 0.0 && t2 >= 0.0 {
         Some(t1.min(t2))
     } else if t1 >= 0.0 {
@@ -117,76 +107,36 @@ fn ray_circle_intersection(ray: &Ray, circle: &Circle) -> Option<f64> {
     }
 }
 
-fn teleport_position(pos: DVec2, from: &Circle, to: &Circle) -> DVec2 {
-    let x_local = pos.x - from.pos.x;
-    let y_local = pos.y - from.pos.y;
-
-    let cos_r1 = (-from.rot).cos();
-    let sin_r1 = (-from.rot).sin();
-    let x_rot = x_local * cos_r1 - y_local * sin_r1;
-    let y_rot = x_local * sin_r1 + y_local * cos_r1;
-
-    let x_local_final = x_rot / from.r;
-    let y_local_final = y_rot / from.r;
-
-    let x_scaled = x_local_final * to.r;
-    let y_scaled = y_local_final * to.r;
-
-    let cos_r2 = to.rot.cos();
-    let sin_r2 = to.rot.sin();
-    let x_rot2 = x_scaled * cos_r2 - y_scaled * sin_r2;
-    let y_rot2 = x_scaled * sin_r2 + y_scaled * cos_r2;
-
-    let x_final = x_rot2 + to.pos.x;
-    let y_final = y_rot2 + to.pos.y;
-
-    DVec2::new(x_final, y_final)
+fn teleport_position(pos: DVec2, from: &DMat3, to: &DMat3) -> DVec2 {
+    let local = from.inverse().transform_point2(pos);
+    to.transform_point2(local)
 }
 
-fn teleport_direction(dir: DVec2, from: &Circle, to: &Circle) -> DVec2 {
-    let cos_r1 = (-from.rot).cos();
-    let sin_r1 = (-from.rot).sin();
-    let x_rot = dir.x * cos_r1 - dir.y * sin_r1;
-    let y_rot = dir.x * sin_r1 + dir.y * cos_r1;
-
-    let x_local = x_rot / from.r;
-    let y_local = y_rot / from.r;
-
-    let x_scaled = x_local * to.r;
-    let y_scaled = y_local * to.r;
-
-    let cos_r2 = to.rot.cos();
-    let sin_r2 = to.rot.sin();
-    let x_final = x_scaled * cos_r2 - y_scaled * sin_r2;
-    let y_final = x_scaled * sin_r2 + y_scaled * cos_r2;
-
-    DVec2::new(x_final, y_final)
+fn teleport_direction(dir: DVec2, from: &DMat3, to: &DMat3) -> DVec2 {
+    let local = from.inverse().transform_vector2(dir);
+    to.transform_vector2(local)
 }
 
-fn circle_invert_ray_direction(ray: &Ray, circle: &Circle) -> DVec2 {
-    let p = ray.o - circle.pos;
-    let d = ray.d;
-
+fn circle_invert_ray_direction(ray: &Ray, circle: &DMat3) -> DVec2 {
+    let inv = circle.inverse();
+    let p = inv.transform_point2(ray.o);
+    let d = inv.transform_vector2(ray.d);
     let r2 = p.dot(p);
     if r2 == 0.0 {
-        return d;
+        return ray.d;
     }
-
     let dot = p.dot(d);
-
     let num = d * r2 - p * (2.0 * dot);
     let denom = r2 * r2;
-
-    let inv = num * (circle.r * circle.r) / denom;
-
-    let orig_len = d.length();
-    let inv_len = inv.length();
+    let inv_local = num / denom;
+    let inv_world = circle.transform_vector2(inv_local);
+    let orig_len = ray.d.length();
+    let inv_len = inv_world.length();
     if inv_len == 0.0 {
-        return DVec2::ZERO;
+        DVec2::ZERO
+    } else {
+        inv_world * (orig_len / inv_len)
     }
-
-    let scale = orig_len / inv_len;
-    inv * scale
 }
 
 fn intersect_circle_portal(ray: &Ray, portal: &Portal) -> (Option<f64>, bool, Option<Ray>) {
@@ -856,26 +806,29 @@ impl eframe::App for Portals2D {
                 let segments = travel_ray(&self.ray, &self.portal, &self.rendering_settings);
                 draw_segments(&painter, &segments, &self.drawing_settings);
 
+                let (mut pos1, _, r1) = mat_to_trs(&self.portal.c1);
                 painter.circle_stroke(
-                    self.portal.c1.pos,
-                    self.portal.c1.r - self.drawing_settings.portal_thickness / 2.,
+                    pos1,
+                    r1 - self.drawing_settings.portal_thickness / 2.,
                     Stroke::new(
                         self.drawing_settings.portal_thickness as f32,
                         Color32::ORANGE,
                     ),
                 );
+                point_ui_mat(ui, mat, &mut pos1, 1., 1.);
+                set_pos(&mut self.portal.c1, pos1);
 
+                let (mut pos2, _, r2) = mat_to_trs(&self.portal.c2);
                 painter.circle_stroke(
-                    self.portal.c2.pos,
-                    self.portal.c2.r - self.drawing_settings.portal_thickness / 2.,
+                    pos2,
+                    r2 - self.drawing_settings.portal_thickness / 2.,
                     Stroke::new(
                         self.drawing_settings.portal_thickness as f32,
                         Color32::LIGHT_BLUE,
                     ),
                 );
-
-                point_ui_mat(ui, mat, &mut self.portal.c1.pos, 1., 1.);
-                point_ui_mat(ui, mat, &mut self.portal.c2.pos, 1., 1.);
+                point_ui_mat(ui, mat, &mut pos2, 1., 1.);
+                set_pos(&mut self.portal.c2, pos2);
 
                 point_direction_ui_mat(ui, mat, self.ray.o, &mut self.ray.d, 1., 1.);
                 point_ui_mat(ui, mat, &mut self.ray.o, 1., 1.);
@@ -899,21 +852,31 @@ impl eframe::App for Portals2D {
                 ui.separator();
                 ui.horizontal(|ui| {
                     ui.label("Portal 1:");
-                    egui_f64(ui, &mut self.portal.c1.pos.x);
-                    egui_f64(ui, &mut self.portal.c1.pos.y);
+                    let (mut pos, mut rot, mut r) = mat_to_trs(&self.portal.c1);
+                    let mut changed = false;
+                    changed |= egui_f64(ui, &mut pos.x);
+                    changed |= egui_f64(ui, &mut pos.y);
                     ui.separator();
-                    egui_angle_f64(ui, &mut self.portal.c1.rot);
+                    changed |= egui_angle_f64(ui, &mut rot);
                     ui.separator();
-                    egui_f64_positive(ui, &mut self.portal.c1.r);
+                    changed |= egui_f64_positive(ui, &mut r);
+                    if changed {
+                        self.portal.c1 = trs_to_mat(pos, rot, r);
+                    }
                 });
                 ui.horizontal(|ui| {
                     ui.label("Portal 2:");
-                    egui_f64(ui, &mut self.portal.c2.pos.x);
-                    egui_f64(ui, &mut self.portal.c2.pos.y);
+                    let (mut pos, mut rot, mut r) = mat_to_trs(&self.portal.c2);
+                    let mut changed = false;
+                    changed |= egui_f64(ui, &mut pos.x);
+                    changed |= egui_f64(ui, &mut pos.y);
                     ui.separator();
-                    egui_angle_f64(ui, &mut self.portal.c2.rot);
+                    changed |= egui_angle_f64(ui, &mut rot);
                     ui.separator();
-                    egui_f64_positive(ui, &mut self.portal.c2.r);
+                    changed |= egui_f64_positive(ui, &mut r);
+                    if changed {
+                        self.portal.c2 = trs_to_mat(pos, rot, r);
+                    }
                 });
                 ui.horizontal(|ui| {
                     ui.label("Portal type:");


### PR DESCRIPTION
## Summary
- replace circle portal representation with DMat3 transforms
- update ray teleportation and intersection math to use unit-circle matrix transforms
- wire up UI to edit portal transforms via matrix decomposition

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6893c7342360832db19fffa71aaa029a