### PR TITLE
Add flat and semicircle portals

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -162,7 +162,9 @@ fn cross(a: DVec2, b: DVec2) -> f64 {
     a.x * b.y - a.y * b.x
 }
 
-fn ray_segment_intersection(ray: &Ray, a: DVec2, b: DVec2) -> Option<f64> {
+fn ray_segment_intersection(ray: &Ray) -> Option<f64> {
+    let a = DVec2::new(-1.0, 0.0);
+    let b = DVec2::new(1.0, 0.0);
     let r = ray.d;
     let s = b - a;
     let denom = cross(r, s);
@@ -179,45 +181,29 @@ fn ray_segment_intersection(ray: &Ray, a: DVec2, b: DVec2) -> Option<f64> {
 }
 
 fn ray_semicircle_intersection(ray: &Ray) -> Option<f64> {
-    let p0 = DVec2::new(-1.0, 0.0);
-    let p1 = DVec2::new(0.0, 1.0);
-    let center = (p0 + p1) * 0.5;
-    let radius = (p1 - p0).length() * 0.5;
-    let normal = DVec2::new(-(p1 - p0).y, (p1 - p0).x);
-
-    let o = ray.o - center;
-    let d = ray.d;
-    let a = d.dot(d);
-    let b = 2.0 * o.dot(d);
-    let c = o.dot(o) - radius * radius;
-    let disc = b * b - 4.0 * a * c;
-    if disc < 0.0 {
+    let a = ray.d.dot(ray.d);
+    let b = 2.0 * ray.o.dot(ray.d);
+    let c = ray.o.dot(ray.o) - 1.0;
+    let discriminant = b * b - 4.0 * a * c;
+    if discriminant < 0.0 {
         return None;
     }
-    let sqrt_disc = disc.sqrt();
-    let q = -0.5 * (b + b.signum() * sqrt_disc);
-    let mut t0 = q / a;
-    let mut t1 = c / q;
-    if t0 > t1 {
-        std::mem::swap(&mut t0, &mut t1);
-    }
-    let check = |t: f64| -> Option<f64> {
-        const EPS: f64 = 1e-12;
-        if t >= EPS {
+    let sqrt_disc = discriminant.sqrt();
+    let t1 = (-b - sqrt_disc) / (2.0 * a);
+    let t2 = (-b + sqrt_disc) / (2.0 * a);
+    let mut res: Option<f64> = None;
+    for &t in [t1, t2].iter() {
+        if t >= 1e-12 {
             let p = ray.offset(t);
-            if (p - center).dot(normal) <= EPS {
-                Some(t)
-            } else {
-                None
+            if p.y >= -1e-12 {
+                res = match res {
+                    Some(current) if current <= t => Some(current),
+                    _ => Some(t),
+                };
             }
-        } else {
-            None
         }
-    };
-    if let Some(t) = check(t0) {
-        return Some(t);
     }
-    check(t1)
+    res
 }
 
 fn teleport_position(pos: DVec2, from: &DMat3, to: &DMat3) -> DVec2 {
@@ -250,157 +236,55 @@ fn circle_invert_ray_direction(ray: &Ray) -> DVec2 {
     }
 }
 
-fn intersect_circle_portal(ray: &Ray, portal: &Portal) -> (Option<f64>, bool, Option<Ray>) {
-    let inv1 = portal.c1.inverse();
-    let inv2 = portal.c2.inverse();
-    let t1 = ray_circle_intersection(&ray.transform(&inv1));
-    let t2 = ray_circle_intersection(&ray.transform(&inv2));
-
-    if let Some(t1_val) = t1 {
-        if t2.is_none() || t1_val < t2.unwrap() {
-            let new_pos = teleport_position(ray.offset(t1_val), &portal.c1, &portal.c2);
-            let mut new_dir = teleport_direction(ray.d, &portal.c1, &portal.c2);
-
-            match portal.portal_type {
-                PortalType::Wormhole => {
-                    let local_ray = Ray::new(new_pos, new_dir).transform(&inv2);
-                    let inverted = circle_invert_ray_direction(&local_ray);
-                    new_dir = portal.c2.transform_vector2(inverted);
-                }
-                PortalType::Perspective => {
-                    new_dir = -new_dir;
-                }
-                _ => {}
-            }
-
-            return (
-                Some(t1_val),
-                true,
-                Some(Ray {
-                    o: new_pos,
-                    d: new_dir,
-                }),
-            );
-        }
-    }
-
-    if let Some(t2_val) = t2 {
-        if t1.is_none() || t2_val < t1.unwrap() {
-            let new_pos = teleport_position(ray.offset(t2_val), &portal.c2, &portal.c1);
-            let mut new_dir = teleport_direction(ray.d, &portal.c2, &portal.c1);
-
-            match portal.portal_type {
-                PortalType::Wormhole => {
-                    let local_ray = Ray::new(new_pos, new_dir).transform(&inv1);
-                    let inverted = circle_invert_ray_direction(&local_ray);
-                    new_dir = portal.c1.transform_vector2(inverted);
-                }
-                PortalType::Perspective => {
-                    new_dir = -new_dir;
-                }
-                _ => {}
-            }
-
-            return (
-                Some(t2_val),
-                true,
-                Some(Ray {
-                    o: new_pos,
-                    d: new_dir,
-                }),
-            );
-        }
-    }
-
-    (None, false, None)
-}
-
-fn intersect_flat_portal(ray: &Ray, portal: &Portal) -> (Option<f64>, bool, Option<Ray>) {
-    let inv1 = portal.c1.inverse();
-    let inv2 = portal.c2.inverse();
-    let a = DVec2::new(-1.0, 0.0);
-    let b = DVec2::new(0.0, 1.0);
-    let t1 = ray_segment_intersection(&ray.transform(&inv1), a, b);
-    let t2 = ray_segment_intersection(&ray.transform(&inv2), a, b);
-
-    if let Some(t1_val) = t1 {
-        if t2.is_none() || t1_val < t2.unwrap() {
-            let new_pos = teleport_position(ray.offset(t1_val), &portal.c1, &portal.c2);
-            let new_dir = teleport_direction(ray.d, &portal.c1, &portal.c2);
-            return (
-                Some(t1_val),
-                true,
-                Some(Ray {
-                    o: new_pos,
-                    d: new_dir,
-                }),
-            );
-        }
-    }
-
-    if let Some(t2_val) = t2 {
-        if t1.is_none() || t2_val < t1.unwrap() {
-            let new_pos = teleport_position(ray.offset(t2_val), &portal.c2, &portal.c1);
-            let new_dir = teleport_direction(ray.d, &portal.c2, &portal.c1);
-            return (
-                Some(t2_val),
-                true,
-                Some(Ray {
-                    o: new_pos,
-                    d: new_dir,
-                }),
-            );
-        }
-    }
-
-    (None, false, None)
-}
-
-fn intersect_semicircle_portal(ray: &Ray, portal: &Portal) -> (Option<f64>, bool, Option<Ray>) {
-    let inv1 = portal.c1.inverse();
-    let inv2 = portal.c2.inverse();
-    let t1 = ray_semicircle_intersection(&ray.transform(&inv1));
-    let t2 = ray_semicircle_intersection(&ray.transform(&inv2));
-
-    if let Some(t1_val) = t1 {
-        if t2.is_none() || t1_val < t2.unwrap() {
-            let new_pos = teleport_position(ray.offset(t1_val), &portal.c1, &portal.c2);
-            let new_dir = teleport_direction(ray.d, &portal.c1, &portal.c2);
-            return (
-                Some(t1_val),
-                true,
-                Some(Ray {
-                    o: new_pos,
-                    d: new_dir,
-                }),
-            );
-        }
-    }
-
-    if let Some(t2_val) = t2 {
-        if t1.is_none() || t2_val < t1.unwrap() {
-            let new_pos = teleport_position(ray.offset(t2_val), &portal.c2, &portal.c1);
-            let new_dir = teleport_direction(ray.d, &portal.c2, &portal.c1);
-            return (
-                Some(t2_val),
-                true,
-                Some(Ray {
-                    o: new_pos,
-                    d: new_dir,
-                }),
-            );
-        }
-    }
-
-    (None, false, None)
-}
-
 fn intersect_portal(ray: &Ray, portal: &Portal) -> (Option<f64>, bool, Option<Ray>) {
+    let inv1 = portal.c1.inverse();
+    let inv2 = portal.c2.inverse();
+
+    let intersection: fn(&Ray) -> Option<f64> = match portal.portal_type {
+        PortalType::Flat => ray_segment_intersection,
+        PortalType::Semicircle => ray_semicircle_intersection,
+        _ => ray_circle_intersection,
+    };
+
+    let t1 = intersection(&ray.transform(&inv1));
+    let t2 = intersection(&ray.transform(&inv2));
+
+    let (t_hit, from, to, inv_to) = match (t1, t2) {
+        (Some(t1), Some(t2)) => {
+            if t1 < t2 {
+                (t1, &portal.c1, &portal.c2, &inv2)
+            } else {
+                (t2, &portal.c2, &portal.c1, &inv1)
+            }
+        }
+        (Some(t1), None) => (t1, &portal.c1, &portal.c2, &inv2),
+        (None, Some(t2)) => (t2, &portal.c2, &portal.c1, &inv1),
+        (None, None) => return (None, false, None),
+    };
+
+    let new_pos = teleport_position(ray.offset(t_hit), from, to);
+    let mut new_dir = teleport_direction(ray.d, from, to);
+
     match portal.portal_type {
-        PortalType::Flat => intersect_flat_portal(ray, portal),
-        PortalType::Semicircle => intersect_semicircle_portal(ray, portal),
-        _ => intersect_circle_portal(ray, portal),
+        PortalType::Wormhole => {
+            let local_ray = Ray::new(new_pos, new_dir).transform(inv_to);
+            let inverted = circle_invert_ray_direction(&local_ray);
+            new_dir = to.transform_vector2(inverted);
+        }
+        PortalType::Perspective => {
+            new_dir = -new_dir;
+        }
+        _ => {}
     }
+
+    (
+        Some(t_hit),
+        true,
+        Some(Ray {
+            o: new_pos,
+            d: new_dir,
+        }),
+    )
 }
 
 fn travel_ray(
@@ -874,22 +758,15 @@ fn draw_portal_shape(
     match portal_type {
         PortalType::Flat => {
             let a = mat.transform_point2(DVec2::new(-1.0, 0.0));
-            let b = mat.transform_point2(DVec2::new(0.0, 1.0));
+            let b = mat.transform_point2(DVec2::new(1.0, 0.0));
             painter.line_segment(a, b, stroke);
         }
         PortalType::Semicircle => {
-            let p0 = DVec2::new(-1.0, 0.0);
-            let p1 = DVec2::new(0.0, 1.0);
-            let center = (p0 + p1) * 0.5;
-            let radius = (p1 - p0).length() * 0.5;
-            let start_angle = 5.0 * PI / 4.0;
             let segments = 32;
-            let mut prev = mat.transform_point2(
-                center + DVec2::new(radius * start_angle.cos(), radius * start_angle.sin()),
-            );
+            let mut prev = mat.transform_point2(DVec2::new(-1.0, 0.0));
             for i in 1..=segments {
-                let angle = start_angle + PI * i as f64 / segments as f64;
-                let pt_local = center + DVec2::new(radius * angle.cos(), radius * angle.sin());
+                let angle = PI - PI * i as f64 / segments as f64;
+                let pt_local = DVec2::new(angle.cos(), angle.sin());
                 let pt = mat.transform_point2(pt_local);
                 painter.line_segment(prev, pt, stroke);
                 prev = pt;


### PR DESCRIPTION
## Summary
- support new `Flat` and `Semicircle` variants for portals
- handle intersection logic and drawing for flat and semicircle portals
- expose new portal types in the configuration UI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6893e291630c832d938f262472e03547